### PR TITLE
Fixes for Perl 5.37.9 but no version bump. (Deal with eval exception text change)

### DIFF
--- a/t/10_slaymakefile.init/32_act_array.smak
+++ b/t/10_slaymakefile.init/32_act_array.smak
@@ -1,12 +1,12 @@
 include common.smakh
 
 {
-    $ENV{FILE} = $FILE = "32_act_array";
+    $ENV{MYFILE} = $MYFILE = "32_act_array";
 }
 
 default:   depend1 depend2 depend3
-	{ @OUTPUT = `cat $FILE.trace`;
+	{ @OUTPUT = `cat $MYFILE.trace`;
         trace(@_) }
 
 depend%:   my_prereq% your_prereq%
-        ['sh', '-c', 'echo "Building $TARGET with deps ($DEP0, $DEP1) and match ($MATCH0)" >> $FILE.trace']
+        ['sh', '-c', 'echo "Building $TARGET with deps ($DEP0, $DEP1) and match ($MATCH0)" >> $MYFILE.trace']

--- a/t/10_slaymakefile.init/34_act_perl.log.exp
+++ b/t/10_slaymakefile.init/34_act_perl.log.exp
@@ -1,4 +1,4 @@
-34_act_perl.smak, 3: Global symbol "$FILE" requires explicit package name at 34_act_perl.smak line 4. at SlayMakefile.main line 26
+34_act_perl.smak, 3: Global symbol "$AFILE" requires explicit package name at 34_act_perl.smak line 4. at SlayMakefile.main line 26
 Building depend1 with matches: depend1   
 Building depend2 with matches: depend2   
 Building depend3 with matches: depend3   

--- a/t/10_slaymakefile.init/34_act_perl.smak
+++ b/t/10_slaymakefile.init/34_act_perl.smak
@@ -1,7 +1,7 @@
 include common.smakh
 
 {
-    $ENV{FILE} = $FILE = "34_act_array";
+    $ENV{AFILE} = $AFILE = "34_act_array";
 }
 
 default:   depend1 depend2 depend3


### PR DESCRIPTION
Fixes the 5.37.9 test failure, silences "not imported" warnings during test.

The test failure is related to: https://github.com/Perl/perl5/pull/20357

Fixes: https://github.com/Perl/perl5/issues/20864

This is the same as https://github.com/eserte/Slay-Makefile/pull/5 but does not include any version bump or changes to the Makefile.PL

